### PR TITLE
Handle OPTIONS method

### DIFF
--- a/method_handler.go
+++ b/method_handler.go
@@ -70,7 +70,7 @@ func (m *MethodHandler) Handle(method string, handler http.Handler) *MethodHandl
 	method = strings.ToUpper(strings.TrimSpace(method))
 
 	if m.methodsAllowedStr == "" {
-		m.methodsAllowedStr = method
+		m.methodsAllowedStr = "OPTIONS, " + method
 	} else {
 		m.methodsAllowedStr += ", " + method
 	}

--- a/method_handler.go
+++ b/method_handler.go
@@ -98,5 +98,7 @@ func (m *MethodHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	//
 	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Allow#Examples
 	w.Header().Set("Allow", m.methodsAllowedStr)
-	http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+	if r.Method != http.MethodOptions {
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+	}
 }

--- a/method_handler_test.go
+++ b/method_handler_test.go
@@ -47,5 +47,5 @@ func TestMethodHandler(t *testing.T) {
 	expect(t, http.MethodDelete, srv.URL+"/user/42").statusCode(http.StatusOK).
 		bodyEq("DELETE: remove user with ID: 42\n")
 	expect(t, http.MethodPut, srv.URL+"/user/42").statusCode(http.StatusMethodNotAllowed).
-		bodyEq("Method Not Allowed\n").headerEq("Allow", "GET, POST, DELETE")
+		bodyEq("Method Not Allowed\n").headerEq("Allow", "OPTIONS, GET, POST, DELETE")
 }

--- a/method_handler_test.go
+++ b/method_handler_test.go
@@ -48,4 +48,6 @@ func TestMethodHandler(t *testing.T) {
 		bodyEq("DELETE: remove user with ID: 42\n")
 	expect(t, http.MethodPut, srv.URL+"/user/42").statusCode(http.StatusMethodNotAllowed).
 		bodyEq("Method Not Allowed\n").headerEq("Allow", "OPTIONS, GET, POST, DELETE")
+	expect(t, http.MethodOptions, srv.URL+"/user/42").statusCode(http.StatusOK).
+		headerEq("Allow", "OPTIONS, GET, POST, DELETE")
 }


### PR DESCRIPTION
I added a simple way of handling OPTIONS automatically, when `MethodHandler` is in use.

As a potential update, it should handle duplications gracefully (eg. one should be able to register a method to handle OPTIONS on their own).